### PR TITLE
Pin pnpm to 10.33.0

### DIFF
--- a/.github/workflows/deploy-cloudrun-pr.yaml
+++ b/.github/workflows/deploy-cloudrun-pr.yaml
@@ -19,8 +19,6 @@ jobs:
         uses: actions/checkout@v6
 
       - uses: pnpm/action-setup@v5
-        with:
-          version: latest
 
       - name: Setup Node
         uses: actions/setup-node@v6

--- a/.github/workflows/deploy-cloudrun-stg.yaml
+++ b/.github/workflows/deploy-cloudrun-stg.yaml
@@ -14,8 +14,6 @@ jobs:
         uses: actions/checkout@v6
 
       - uses: pnpm/action-setup@v5
-        with:
-          version: latest
 
       - name: Setup Node
         uses: actions/setup-node@v6

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "nuxt-app",
   "private": true,
   "type": "module",
+  "packageManager": "pnpm@10.33.0",
   "scripts": {
     "build": "nuxt build",
     "dev": "nuxt dev",


### PR DESCRIPTION
## Summary

- Add `"packageManager": "pnpm@10.33.0"` to `package.json` — Corepack and `pnpm/action-setup` both honor this field, so local dev, PR previews, and the staging deploy all use the same version automatically.
- Drop the now-redundant `version: latest` from `pnpm/action-setup` in the two deploy workflows (`deploy-cloudrun-stg.yaml`, `deploy-cloudrun-pr.yaml`).

Bumping pnpm in the future = one-line change to `packageManager`; no more workflow drift between branches.

## Test plan
- [x] `pnpm install` succeeds locally with the pinned version
- [ ] PR preview deploy runs green with the new workflow config