### PR TITLE
Refine /i/[id] card design & fix admin LINE auth flow

### DIFF
--- a/components/CardExchangeInfo.vue
+++ b/components/CardExchangeInfo.vue
@@ -1,0 +1,244 @@
+<script lang="ts" setup>
+import type { CardInfo } from "~/schema/CardInfo";
+
+defineProps<{ cardInfo: CardInfo }>();
+</script>
+
+<template>
+  <section
+    class="stub"
+    :aria-label="cardInfo.event ? `${cardInfo.event.name} で交換された名刺` : '名刺交換記録'"
+  >
+    <aside class="stub-rail">
+      <span class="rail-text">EXCHANGE&nbsp;RECORD</span>
+    </aside>
+
+    <span class="stub-perf" aria-hidden="true"></span>
+
+    <div class="stub-body">
+      <div class="row">
+        <span class="row-label">EXCHANGED</span>
+        <span class="row-value mono">{{ cardInfo.exchangeDate || "—" }}</span>
+      </div>
+
+      <div v-if="cardInfo.event" class="event">
+        <span class="event-flag">EVENT</span>
+        <h3 class="event-name">{{ cardInfo.event.name }}</h3>
+        <p v-if="cardInfo.event.description" class="event-desc">
+          {{ cardInfo.event.description }}
+        </p>
+
+        <div class="event-grid">
+          <div v-if="cardInfo.event.place" class="row">
+            <span class="row-label">VENUE</span>
+            <span class="row-value">{{ cardInfo.event.place }}</span>
+          </div>
+          <div v-if="cardInfo.event.date" class="row">
+            <span class="row-label">DATE</span>
+            <span class="row-value mono">{{ cardInfo.event.date }}</span>
+          </div>
+          <div v-if="cardInfo.event.time" class="row">
+            <span class="row-label">TIME</span>
+            <span class="row-value mono">{{ cardInfo.event.time }}</span>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <span class="stub-shimmer" aria-hidden="true"></span>
+  </section>
+</template>
+
+<style scoped>
+/* Ticket stub: left rail + perforation + body
+   Uses CSS mask to punch real notches into the card silhouette so it
+   reads as a torn ticket regardless of the page background. */
+.stub {
+  --notch-r: 0.4rem;
+  --rail-w: 1.55rem;
+  --perf-w: 0px;
+  --gutter: calc(var(--rail-w) + var(--perf-w));
+
+  position: relative;
+  width: min(82vw, 19rem);
+  margin: 1.25rem auto 0.75rem;
+  display: grid;
+  grid-template-columns: var(--rail-w) var(--perf-w) 1fr;
+
+  background: linear-gradient(
+    135deg,
+    rgba(255, 255, 255, 0.06) 0%,
+    rgba(255, 255, 255, 0.025) 100%
+  );
+  color: #ffffff;
+  font-size: 13px;
+  isolation: isolate;
+
+  /* Real cut-out notches via mask */
+  --notch-mask:
+    radial-gradient(circle var(--notch-r) at var(--gutter) 0, transparent 99%, #000 100%),
+    radial-gradient(circle var(--notch-r) at var(--gutter) 100%, transparent 99%, #000 100%);
+  -webkit-mask: var(--notch-mask);
+          mask: var(--notch-mask);
+  -webkit-mask-composite: source-in;
+          mask-composite: intersect;
+
+  border-radius: 0.7rem;
+
+  /* Faux border via inset shadow (real border + mask would look uneven) */
+  box-shadow:
+    inset 0 0 0 1px rgba(255, 255, 255, 0.13),
+    0 14px 32px -20px rgba(0, 0, 0, 0.6);
+}
+
+/* left rail */
+.stub-rail {
+  position: relative;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(255, 255, 255, 0.04);
+}
+.rail-text {
+  writing-mode: vertical-rl;
+  transform: rotate(180deg);
+  white-space: nowrap;
+  font-family: "JetBrains Mono", "SF Mono", ui-monospace, monospace;
+  font-size: 0.55rem;
+  letter-spacing: 0.32em;
+  font-weight: 600;
+  color: rgba(255, 255, 255, 0.55);
+}
+
+/* perforation strip: thin dashed line between rail and body */
+.stub-perf {
+  position: relative;
+  width: 0;
+}
+.stub-perf::before {
+  content: "";
+  position: absolute;
+  top: 0.45rem;
+  bottom: 0.45rem;
+  left: 0;
+  width: 1px;
+  background-image: linear-gradient(
+    to bottom,
+    rgba(255, 255, 255, 0.32) 0 4px,
+    transparent 4px 8px
+  );
+  background-size: 1px 8px;
+  background-repeat: repeat-y;
+}
+
+/* right body */
+.stub-body {
+  padding: 0.8rem 0.95rem 0.85rem 1rem;
+  display: grid;
+  gap: 0.55rem;
+}
+
+/* row primitive */
+.row {
+  display: grid;
+  grid-template-columns: 4rem 1fr;
+  align-items: baseline;
+  column-gap: 0.6rem;
+}
+.row-label {
+  font-family: "JetBrains Mono", "SF Mono", ui-monospace, monospace;
+  font-size: 0.58rem;
+  letter-spacing: 0.18em;
+  color: rgba(255, 255, 255, 0.42);
+  font-weight: 500;
+}
+.row-value {
+  font-size: 0.85rem;
+  font-weight: 500;
+  line-height: 1.4;
+  color: rgba(255, 255, 255, 0.95);
+  word-break: keep-all;
+  overflow-wrap: anywhere;
+  line-break: strict;
+}
+.row-value.mono {
+  font-family: "JetBrains Mono", "SF Mono", ui-monospace, monospace;
+  font-variant-numeric: tabular-nums;
+  letter-spacing: 0.02em;
+}
+
+/* event block */
+.event {
+  position: relative;
+  margin-top: 0.5rem;
+  padding-top: 0.65rem;
+}
+.event::before {
+  content: "";
+  position: absolute;
+  top: 0;
+  left: -1rem;
+  right: -0.95rem;
+  height: 1px;
+  background-image: linear-gradient(
+    to right,
+    rgba(255, 255, 255, 0.18) 0 3px,
+    transparent 3px 6px
+  );
+  background-size: 6px 1px;
+}
+.event-flag {
+  display: inline-block;
+  font-family: "JetBrains Mono", "SF Mono", ui-monospace, monospace;
+  font-size: 0.55rem;
+  letter-spacing: 0.22em;
+  padding: 0.12rem 0.4rem;
+  border: 1px solid #c4ff33;
+  color: #c4ff33;
+  border-radius: 2px;
+  margin-bottom: 0.45rem;
+}
+.event-name {
+  margin: 0 0 0.2rem;
+  font-size: 0.98rem;
+  font-weight: 700;
+  line-height: 1.3;
+  letter-spacing: -0.005em;
+}
+.event-desc {
+  margin: 0 0 0.6rem;
+  font-size: 0.7rem;
+  line-height: 1.55;
+  color: rgba(255, 255, 255, 0.65);
+}
+.event-grid {
+  display: grid;
+  gap: 0.32rem;
+}
+
+/* subtle shimmer on hover */
+.stub-shimmer {
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  z-index: 1;
+  background: linear-gradient(
+    115deg,
+    transparent 38%,
+    rgba(196, 255, 51, 0.08) 50%,
+    transparent 62%
+  );
+  background-size: 220% 100%;
+  background-position: 200% 0;
+  transition: background-position 1.4s ease;
+}
+.stub:hover .stub-shimmer {
+  background-position: -120% 0;
+}
+
+@media (max-width: 360px) {
+  .stub { font-size: 12px; }
+  .stub-body { padding: 0.7rem 0.8rem 0.75rem 0.85rem; }
+  .row { grid-template-columns: 3.6rem 1fr; column-gap: 0.45rem; }
+}
+</style>

--- a/components/CardExchangeInfo.vue
+++ b/components/CardExchangeInfo.vue
@@ -5,240 +5,113 @@ defineProps<{ cardInfo: CardInfo }>();
 </script>
 
 <template>
-  <section
-    class="stub"
-    :aria-label="cardInfo.event ? `${cardInfo.event.name} で交換された名刺` : '名刺交換記録'"
-  >
-    <aside class="stub-rail">
-      <span class="rail-text">EXCHANGE&nbsp;RECORD</span>
-    </aside>
-
-    <span class="stub-perf" aria-hidden="true"></span>
-
-    <div class="stub-body">
-      <div class="row">
-        <span class="row-label">EXCHANGED</span>
-        <span class="row-value mono">{{ cardInfo.exchangeDate || "—" }}</span>
-      </div>
-
-      <div v-if="cardInfo.event" class="event">
-        <span class="event-flag">EVENT</span>
-        <h3 class="event-name">{{ cardInfo.event.name }}</h3>
-        <p v-if="cardInfo.event.description" class="event-desc">
-          {{ cardInfo.event.description }}
-        </p>
-
-        <div class="event-grid">
-          <div v-if="cardInfo.event.place" class="row">
-            <span class="row-label">VENUE</span>
-            <span class="row-value">{{ cardInfo.event.place }}</span>
-          </div>
-          <div v-if="cardInfo.event.date" class="row">
-            <span class="row-label">DATE</span>
-            <span class="row-value mono">{{ cardInfo.event.date }}</span>
-          </div>
-          <div v-if="cardInfo.event.time" class="row">
-            <span class="row-label">TIME</span>
-            <span class="row-value mono">{{ cardInfo.event.time }}</span>
-          </div>
+  <section class="card">
+    <div v-if="cardInfo.event" class="event">
+      <h3 class="event-heading">この名刺を交換したイベント</h3>
+      <p class="event-name">{{ cardInfo.event.name }}</p>
+      <p v-if="cardInfo.event.description" class="event-desc">
+        {{ cardInfo.event.description }}
+      </p>
+      <dl class="meta event-meta">
+        <div v-if="cardInfo.event.place" class="row">
+          <dt>会場</dt>
+          <dd>{{ cardInfo.event.place }}</dd>
         </div>
-      </div>
+        <div v-if="cardInfo.event.date" class="row">
+          <dt>開催日</dt>
+          <dd>{{ cardInfo.event.date }}</dd>
+        </div>
+        <div v-if="cardInfo.event.time" class="row">
+          <dt>時間</dt>
+          <dd>{{ cardInfo.event.time }}</dd>
+        </div>
+      </dl>
     </div>
 
-    <span class="stub-shimmer" aria-hidden="true"></span>
+    <dl class="meta" :class="{ 'with-divider': !!cardInfo.event }">
+      <div v-if="cardInfo.recipient" class="row">
+        <dt>To</dt>
+        <dd class="recipient">{{ cardInfo.recipient }}</dd>
+      </div>
+      <div class="row">
+        <dt>交換日</dt>
+        <dd>{{ cardInfo.exchangeDate || "—" }}</dd>
+      </div>
+    </dl>
   </section>
 </template>
 
 <style scoped>
-/* Ticket stub: left rail + perforation + body
-   Uses CSS mask to punch real notches into the card silhouette so it
-   reads as a torn ticket regardless of the page background. */
-.stub {
-  --notch-r: 0.4rem;
-  --rail-w: 1.55rem;
-  --perf-w: 0px;
-  --gutter: calc(var(--rail-w) + var(--perf-w));
-
-  position: relative;
-  width: min(82vw, 19rem);
-  margin: 1.25rem auto 0.75rem;
-  display: grid;
-  grid-template-columns: var(--rail-w) var(--perf-w) 1fr;
-
-  background: linear-gradient(
-    135deg,
-    rgba(255, 255, 255, 0.06) 0%,
-    rgba(255, 255, 255, 0.025) 100%
-  );
+.card {
+  width: min(85vw, 15.5em);
+  margin: 0.9em auto 0;
+  padding: 0.55em 0.85em 0.6em;
+  border: 1px solid rgba(255, 255, 255, 0.85);
+  border-radius: 1em;
   color: #ffffff;
-  font-size: 13px;
-  isolation: isolate;
-
-  /* Real cut-out notches via mask */
-  --notch-mask:
-    radial-gradient(circle var(--notch-r) at var(--gutter) 0, transparent 99%, #000 100%),
-    radial-gradient(circle var(--notch-r) at var(--gutter) 100%, transparent 99%, #000 100%);
-  -webkit-mask: var(--notch-mask);
-          mask: var(--notch-mask);
-  -webkit-mask-composite: source-in;
-          mask-composite: intersect;
-
-  border-radius: 0.7rem;
-
-  /* Faux border via inset shadow (real border + mask would look uneven) */
-  box-shadow:
-    inset 0 0 0 1px rgba(255, 255, 255, 0.13),
-    0 14px 32px -20px rgba(0, 0, 0, 0.6);
+  font-size: 0.92em;
 }
 
-/* left rail */
-.stub-rail {
-  position: relative;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  background: rgba(255, 255, 255, 0.04);
-}
-.rail-text {
-  writing-mode: vertical-rl;
-  transform: rotate(180deg);
-  white-space: nowrap;
-  font-family: "JetBrains Mono", "SF Mono", ui-monospace, monospace;
-  font-size: 0.55rem;
-  letter-spacing: 0.32em;
-  font-weight: 600;
-  color: rgba(255, 255, 255, 0.55);
-}
-
-/* perforation strip: thin dashed line between rail and body */
-.stub-perf {
-  position: relative;
-  width: 0;
-}
-.stub-perf::before {
-  content: "";
-  position: absolute;
-  top: 0.45rem;
-  bottom: 0.45rem;
-  left: 0;
-  width: 1px;
-  background-image: linear-gradient(
-    to bottom,
-    rgba(255, 255, 255, 0.32) 0 4px,
-    transparent 4px 8px
-  );
-  background-size: 1px 8px;
-  background-repeat: repeat-y;
-}
-
-/* right body */
-.stub-body {
-  padding: 0.8rem 0.95rem 0.85rem 1rem;
+.meta {
+  margin: 0;
   display: grid;
-  gap: 0.55rem;
+  gap: 0.15em;
+}
+.meta.with-divider {
+  margin-top: 0.4em;
+  padding-top: 0.35em;
+  border-top: 1px solid rgba(255, 255, 255, 0.22);
 }
 
-/* row primitive */
 .row {
   display: grid;
-  grid-template-columns: 4rem 1fr;
+  grid-template-columns: 3.4em 1fr;
   align-items: baseline;
-  column-gap: 0.6rem;
+  column-gap: 0.5em;
 }
-.row-label {
-  font-family: "JetBrains Mono", "SF Mono", ui-monospace, monospace;
-  font-size: 0.58rem;
-  letter-spacing: 0.18em;
-  color: rgba(255, 255, 255, 0.42);
-  font-weight: 500;
+.row dt {
+  margin: 0;
+  font-size: 0.66em;
+  color: rgba(255, 255, 255, 0.6);
+  letter-spacing: 0.02em;
 }
-.row-value {
-  font-size: 0.85rem;
+.row dd {
+  margin: 0;
+  font-size: 0.86em;
   font-weight: 500;
-  line-height: 1.4;
-  color: rgba(255, 255, 255, 0.95);
+  line-height: 1.35;
   word-break: keep-all;
   overflow-wrap: anywhere;
   line-break: strict;
 }
-.row-value.mono {
-  font-family: "JetBrains Mono", "SF Mono", ui-monospace, monospace;
-  font-variant-numeric: tabular-nums;
-  letter-spacing: 0.02em;
+.row dd.recipient {
+  font-size: 0.92em;
+  font-weight: 600;
 }
 
-/* event block */
-.event {
-  position: relative;
-  margin-top: 0.5rem;
-  padding-top: 0.65rem;
-}
-.event::before {
-  content: "";
-  position: absolute;
-  top: 0;
-  left: -1rem;
-  right: -0.95rem;
-  height: 1px;
-  background-image: linear-gradient(
-    to right,
-    rgba(255, 255, 255, 0.18) 0 3px,
-    transparent 3px 6px
-  );
-  background-size: 6px 1px;
-}
-.event-flag {
-  display: inline-block;
-  font-family: "JetBrains Mono", "SF Mono", ui-monospace, monospace;
-  font-size: 0.55rem;
-  letter-spacing: 0.22em;
-  padding: 0.12rem 0.4rem;
-  border: 1px solid #c4ff33;
-  color: #c4ff33;
-  border-radius: 2px;
-  margin-bottom: 0.45rem;
+.event-heading {
+  margin: 0 0 0.18em;
+  font-size: 0.7em;
+  font-weight: 600;
+  color: rgba(255, 255, 255, 0.7);
+  letter-spacing: 0.04em;
 }
 .event-name {
-  margin: 0 0 0.2rem;
-  font-size: 0.98rem;
-  font-weight: 700;
+  margin: 0 0 0.15em;
+  font-size: 0.96em;
+  font-weight: 600;
   line-height: 1.3;
-  letter-spacing: -0.005em;
+  word-break: keep-all;
+  overflow-wrap: anywhere;
+  line-break: strict;
 }
 .event-desc {
-  margin: 0 0 0.6rem;
-  font-size: 0.7rem;
-  line-height: 1.55;
-  color: rgba(255, 255, 255, 0.65);
+  margin: 0 0 0.35em;
+  font-size: 0.74em;
+  line-height: 1.5;
+  color: rgba(255, 255, 255, 0.78);
 }
-.event-grid {
-  display: grid;
-  gap: 0.32rem;
-}
-
-/* subtle shimmer on hover */
-.stub-shimmer {
-  position: absolute;
-  inset: 0;
-  pointer-events: none;
-  z-index: 1;
-  background: linear-gradient(
-    115deg,
-    transparent 38%,
-    rgba(196, 255, 51, 0.08) 50%,
-    transparent 62%
-  );
-  background-size: 220% 100%;
-  background-position: 200% 0;
-  transition: background-position 1.4s ease;
-}
-.stub:hover .stub-shimmer {
-  background-position: -120% 0;
-}
-
-@media (max-width: 360px) {
-  .stub { font-size: 12px; }
-  .stub-body { padding: 0.7rem 0.8rem 0.75rem 0.85rem; }
-  .row { grid-template-columns: 3.6rem 1fr; column-gap: 0.45rem; }
+.event-meta {
+  margin-top: 0.25em;
 }
 </style>

--- a/middleware/admin-auth.global.ts
+++ b/middleware/admin-auth.global.ts
@@ -1,8 +1,16 @@
 export default defineNuxtRouteMiddleware(async (to) => {
   if (!to.path.startsWith("/admin")) return;
   if (to.path === "/admin/login") return;
-  const me = await $fetch<{ authenticated: boolean }>("/api/admin/auth/me");
-  if (!me.authenticated) {
+
+  const headers = import.meta.server ? useRequestHeaders(["cookie"]) : undefined;
+  let authenticated = false;
+  try {
+    const me = await $fetch<{ authenticated: boolean }>("/api/admin/auth/me", { headers });
+    authenticated = me.authenticated;
+  } catch {
+    authenticated = false;
+  }
+  if (!authenticated) {
     return navigateTo("/admin/login");
   }
 });

--- a/pages/i/[id]/index.vue
+++ b/pages/i/[id]/index.vue
@@ -1,52 +1,20 @@
 <script lang="ts" setup>
-import { CardInfo } from "~/schema/CardInfo";
+import type { CardInfo } from "~/schema/CardInfo";
+import { SNS_ORDER } from "~/type/sns";
 
 const id = useRoute().params.id;
 const cardInfo: CardInfo | null = await useFetch(`/api/card-data?id=${id}`)
-  .then((res) => {
-    return res.data.value as CardInfo;
-  })
-  .catch(() => {
-    return null;
-  });
+  .then((res) => res.data.value as CardInfo)
+  .catch(() => null);
 </script>
 
 <template>
   <div class="page-root">
-    <div class="exchange-info">
-      <div v-if="!cardInfo">名刺情報の読み取りに失敗しました</div>
-      <div v-else>
-        この名刺の交換日は
-        <p class="exchange-date">
-          {{ cardInfo.exchangeDate }}
-        </p>
-        <div class="event-area" v-if="cardInfo.event">
-          <hr />
-          <p class="name">{{ cardInfo.event.name }}</p>
-          <p class="desc" v-show="cardInfo.event.description">
-            {{ cardInfo.event.description }}
-          </p>
-          <p class="place" v-show="cardInfo.event.place">
-            {{ cardInfo.event.place }}
-          </p>
-          <p class="date" v-show="cardInfo.event.date">
-            {{ cardInfo.event.date }}
-          </p>
-          <p class="time" v-show="cardInfo.event.time">
-            {{ cardInfo.event.time }}
-          </p>
-        </div>
-      </div>
-    </div>
     <Profile />
+    <CardExchangeInfo v-if="cardInfo" :card-info="cardInfo" />
+    <p v-else class="load-error">名刺情報の読み取りに失敗しました</p>
     <div class="sns-area">
-      <SNSItem snsType="github" />
-      <SNSItem snsType="gmail" />
-      <SNSItem snsType="x" />
-      <SNSItem snsType="discord" />
-      <SNSItem snsType="line" />
-      <SNSItem snsType="wantedly" />
-      <SNSItem snsType="linkedin" />
+      <SNSItem v-for="type in SNS_ORDER" :key="type" :sns-type="type" />
     </div>
   </div>
 </template>
@@ -57,53 +25,18 @@ const cardInfo: CardInfo | null = await useFetch(`/api/card-data?id=${id}`)
   flex-direction: column;
   padding-bottom: 4em;
 }
-
 .sns-area {
   display: flex;
   flex-wrap: wrap;
   justify-content: center;
-  margin: 0 auto;
   max-width: 40rem;
+  margin: 0 auto;
+  gap: 0.5rem;
 }
-
-.sns-item {
-  width: min(300px, 90vw);
-  height: 50px;
-}
-
-.exchange-info {
-  width: min(85vw, 17rem);
-  border: 1px solid white;
-  padding: 0.75em;
-  border-radius: 1em;
+.load-error {
+  margin: 1.25rem auto 0.75rem;
   text-align: center;
-  margin: 2em auto 0;
-
-  .exchange-date {
-    font-size: 1.5em;
-    font-weight: bold;
-    margin: 0.4em 1em;
-  }
-
-  .event-area {
-    .name {
-      margin: 1em 0 0.5em;
-    }
-    .desc {
-      font-size: 0.8em;
-      margin: 0 0 0.4em 0;
-    }
-    .place {
-      margin: 1em 0;
-    }
-    .date {
-      margin: 1em 0 0.2em 0;
-      font-size: 1.2em;
-    }
-    .time {
-      margin: 0 0 0.4em 0;
-      font-size: 1.2em;
-    }
-  }
+  color: rgba(255, 255, 255, 0.6);
+  font-size: 0.9rem;
 }
 </style>

--- a/schema/CardInfo.ts
+++ b/schema/CardInfo.ts
@@ -9,6 +9,7 @@ interface EventInfo {
 
 interface CardInfo {
   id: string;
+  recipient?: string;
   exchangeDate?: string;
   event?: EventInfo;
 }

--- a/server/api/card-data.get.ts
+++ b/server/api/card-data.get.ts
@@ -20,6 +20,7 @@ export default defineEventHandler(async (event) => {
     return sendError(event, new Error("card not found"));
   }
   resp.id = cardID;
+  resp.recipient = cardData.recipient;
   resp.exchangeDate = cardData.exchangeDate;
   if (cardData.eventID) {
     const eventData = await getEventData(cardData.eventID);

--- a/server/utils/line-auth.ts
+++ b/server/utils/line-auth.ts
@@ -1,5 +1,5 @@
 import crypto from "node:crypto";
-import { createRemoteJWKSet, jwtVerify } from "jose";
+import { createRemoteJWKSet, decodeProtectedHeader, jwtVerify } from "jose";
 import type { H3Event } from "h3";
 
 const LINE_AUTHORIZE_URL = "https://access.line.me/oauth2/v2.1/authorize";
@@ -12,7 +12,12 @@ const NONCE_COOKIE = "line_oauth_nonce";
 
 let jwksCache: ReturnType<typeof createRemoteJWKSet> | null = null;
 function getJwks() {
-  if (!jwksCache) jwksCache = createRemoteJWKSet(new URL(LINE_JWKS_URL));
+  if (!jwksCache) {
+    jwksCache = createRemoteJWKSet(new URL(LINE_JWKS_URL), {
+      cacheMaxAge: 60 * 60 * 1000,
+      cooldownDuration: 30 * 1000,
+    });
+  }
   return jwksCache;
 }
 
@@ -94,10 +99,34 @@ export interface LineIdTokenClaims {
 
 export async function verifyIdToken(idToken: string, expectedNonce: string | null): Promise<LineIdTokenClaims> {
   const cfg = lineConfig();
-  const { payload } = await jwtVerify(idToken, getJwks(), {
-    issuer: LINE_ISSUER,
-    audience: cfg.channelId,
-  });
+  const expectedAud = String(cfg.channelId);
+  const header = decodeProtectedHeader(idToken);
+  const alg = header.alg;
+
+  // Verify signature + iss + exp only via jose; audience is checked manually
+  // below to avoid jose's strict type handling of the audience option.
+  const verifyOptions = { issuer: LINE_ISSUER };
+  let payload: Record<string, unknown>;
+  if (alg === "HS256") {
+    const secret = new TextEncoder().encode(cfg.channelSecret);
+    ({ payload } = await jwtVerify(idToken, secret, {
+      ...verifyOptions,
+      algorithms: ["HS256"],
+    }));
+  } else if (alg === "ES256") {
+    ({ payload } = await jwtVerify(idToken, getJwks(), {
+      ...verifyOptions,
+      algorithms: ["ES256"],
+    }));
+  } else {
+    throw createError({ statusCode: 401, statusMessage: `unsupported id_token alg: ${alg}` });
+  }
+
+  const aud = payload.aud;
+  const audMatches = Array.isArray(aud) ? aud.includes(expectedAud) : aud === expectedAud;
+  if (!audMatches) {
+    throw createError({ statusCode: 401, statusMessage: "audience mismatch" });
+  }
   if (expectedNonce && payload.nonce !== expectedNonce) {
     throw createError({ statusCode: 401, statusMessage: "nonce mismatch" });
   }


### PR DESCRIPTION
## Summary

### `/i/[id]` ページのデザイン刷新
- 交換・イベント情報を専用コンポーネント `CardExchangeInfo` に切り出し、Profile カードと同じビジュアル言語 (白い細枠 + 角丸 + 半透明背景) で統一。
- イベント情報を上、To / 交換日を下に置き、間にヘアラインで仕切るレイアウト。
- 既存の `CardData.recipient` を `CardInfo` / `/api/card-data` まで流して **To: 受取人名** を表示できるように。

### Admin LINE 認証フローのバグ修正 (PR #135 後に発覚)
ローカルで `/admin/login` から実 LINE Login を試して見つかった問題を同梱:

| 症状 | 原因 | 修正 |
|---|---|---|
| LINE 認可後 callback が無限ループ | `NUXT_LINE_CALLBACK_URL` が `/admin/auth/callback` で API ルートと不整合 | `.env` / Cloud Run env を `/api/admin/auth/callback` に統一 (本コミット外、別途反映済) |
| `Unsupported "alg"` で id_token 検証失敗 | LINE Login の id_token は **HS256 (Channel Secret)** だが ES256 (JWKS) を前提にしていた | `decodeProtectedHeader` で alg を判別して HS256/ES256 を分岐 |
| `audOption.includes is not a function` | jose の `audience` オプションの型扱い不整合 | audience は payload を取り出してから手動比較 |
| ログイン後も `/admin/login` に戻り続ける | SSR で `$fetch('/api/admin/auth/me')` がブラウザ cookie を持たない | middleware で `useRequestHeaders(['cookie'])` を引き継ぎ |

## Test plan
- [x] `pnpm build` succeeds
- [x] ローカルで `/admin/login` から実 LINE Login が完走、`/admin` ダッシュボードに着地
- [x] /admin/cards で新規カード作成、発行された ID を `/i/<id>` で表示できる
- [ ] 本番 (https://card.shion.pro/i/<id>) でデザイン確認